### PR TITLE
docs: remove license mention in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,3 @@ ember install ember-asciinema-player
 ## Contributing
 
 See the [Contributing](CONTRIBUTING.md) guide for details.
-
-
-## License
-
-This project is licensed under the [MIT License](LICENSE.md).


### PR DESCRIPTION
Remove the auto-generated license mention from readme.