### PR TITLE
feature: add support for asciinema-player options as component arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,22 @@ ember install ember-asciinema-player
 Add the player component to a template:
 
 ```hbs
-<Heap::Player @data={{@asciicastData}} />
+<Heap::Player @data={{@asciicastData}} @poster='npt:1:30' />
 ```
+
+Pass supported options as component arguments:
+`autoPlay`,
+`loop`,
+`startAt`,
+`speed`,
+`idleTimeLimit`,
+`theme`,
+`poster`,
+`fit`,
+`controls`,
+`markers`,
+`pauseOnMarkers`.  Learn more about these options in
+[the asciinema-player docs](https://github.com/asciinema/asciinema-player#options).
 
 This example assumes that `@asciicastData` is a preloaded asciicast file.
 Asciicast may be fetched from a remote source.  For example, to preload

--- a/addon/components/heap/player/index.js
+++ b/addon/components/heap/player/index.js
@@ -22,6 +22,48 @@ export default class HeapPlayerComponent extends Component {
    */
   initialized = false;
 
+  /**
+   * Options of the underlying AsciinemaPlayer support by this component,
+   * which may be passed as named arguments to the player.
+   * @type {string[]}
+   * @see https://github.com/asciinema/asciinema-player#options
+   */
+  supportedOptions = new Array(
+    'autoPlay',
+    'loop',
+    'startAt',
+    'speed',
+    'idleTimeLimit',
+    'theme',
+    'poster',
+    'fit',
+    'controls',
+    'markers',
+    'pauseOnMarkers',
+  );
+
+  /**
+   * An object of options where each possible key from `supportOptions` is
+   * included if and only if its associated value was passed to the component
+   * as an argument.
+   *
+   * E.g. `@autoPlay={{true}} @fit='both'` results in
+   * the options object `{autoPlay: true, fit: 'both'}`.
+   * @type {object}
+   * @see https://github.com/asciinema/asciinema-player#options
+   */
+  get options() {
+    return this.supportedOptions.reduce(
+      (obj, key) => {
+        console.log(key, this.args?.[key]);
+        return this.args?.[key] !== undefined
+          ? { ...obj, [key]: this.args[key] }
+          : obj
+      },
+      {}
+    );
+  }
+
   // =methods
 
   /**
@@ -58,7 +100,7 @@ export default class HeapPlayerComponent extends Component {
   @action
   initializePlayer(containerElement) {
     const { data } = this.args;
-    this.create({ data }, containerElement, { poster: 'npt:1:30' });
+    this.create({ data }, containerElement, this.options);
   }
 
   /**

--- a/addon/components/heap/player/index.js
+++ b/addon/components/heap/player/index.js
@@ -23,7 +23,7 @@ export default class HeapPlayerComponent extends Component {
   initialized = false;
 
   /**
-   * Options of the underlying AsciinemaPlayer support by this component,
+   * Options of the underlying AsciinemaPlayer supported by this component,
    * which may be passed as named arguments to the player.
    * @type {string[]}
    * @see https://github.com/asciinema/asciinema-player#options

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -29,8 +29,30 @@
     @href="https://github.com/asciinema/asciinema-player"
     @icon="external-link"
   >asciinema-player</Hds::Link::Inline>.
+  The following <Hds::Link::Inline
+    @href="https://github.com/asciinema/asciinema-player#options"
+    @icon="external-link"
+  >supported options of asciinema-player</Hds::Link::Inline>
+  may be passed as component arguments:
+  <code class="hds-font-family-mono-code hds-foreground-highlight">autoPlay</code>,
+  <code class="hds-font-family-mono-code hds-foreground-highlight">loop</code>,
+  <code class="hds-font-family-mono-code hds-foreground-highlight">startAt</code>,
+  <code class="hds-font-family-mono-code hds-foreground-highlight">speed</code>,
+  <code class="hds-font-family-mono-code hds-foreground-highlight">idleTimeLimit</code>,
+  <code class="hds-font-family-mono-code hds-foreground-highlight">theme</code>,
+  <code class="hds-font-family-mono-code hds-foreground-highlight">poster</code>,
+  <code class="hds-font-family-mono-code hds-foreground-highlight">fit</code>,
+  <code class="hds-font-family-mono-code hds-foreground-highlight">controls</code>,
+  <code class="hds-font-family-mono-code hds-foreground-highlight">markers</code>,
+  <code class="hds-font-family-mono-code hds-foreground-highlight">pauseOnMarkers</code>.
+  <br>
+  <br>
+  Example usage:
+  <code class="hds-font-family-mono-code hds-foreground-success">
+    &lt;Heap::Player @data={{{'{{this.data}}'}}} @poster='npt:1:30' /&gt;
+  </code>
 </p>
 
-<Heap::Player @data={{@model}} />
+<Heap::Player @data={{@model}} @poster='npt:1:30' />
 
 {{outlet}}

--- a/tests/integration/components/heap/player-test.js
+++ b/tests/integration/components/heap/player-test.js
@@ -18,7 +18,7 @@ module('Integration | Component | heap/player', function (hooks) {
     const asciicastContent = await asciicast.text();
     this.set('data', asciicastContent);
 
-    await render(hbs`<Heap::Player @data={{this.data}} />`);
+    await render(hbs`<Heap::Player @data={{this.data}} @poster='npt:1:30' />`);
     // AsciinemaPlayer does not come with a "ready" event, and its
     // initialization is async.  Therefore tests must `waitUntil` the expected
     // DOM state is reached.


### PR DESCRIPTION
This PR adds support for some asciinema-player options to be passed as component arguments.  See [project documentation](https://github.com/asciinema/asciinema-player#options) for information about each option.